### PR TITLE
Fix a typo - terrian -> terrain

### DIFF
--- a/src/minecraft/org/getspout/spout/gui/settings/MipMapSlider.java
+++ b/src/minecraft/org/getspout/spout/gui/settings/MipMapSlider.java
@@ -29,7 +29,7 @@ public class MipMapSlider extends GenericSlider{
 	public MipMapSlider() {
 		super("Terrain Mipmaps");
 		this.setSliderPosition(ConfigReader.mipmapsPercent);
-		setTooltip("Terrain Mipmaps\nON - reduces the pixelation in far off terrain. However, not all \ngraphic cards support it, and some texture packs handle it poorly.\nOFF - Normal Minecraft terrian.");
+		setTooltip("Terrain Mipmaps\nON - reduces the pixelation in far off terrain. However, not all \ngraphic cards support it, and some texture packs handle it poorly.\nOFF - Normal Minecraft terrain.");
 	}
 	
 	@Override


### PR DESCRIPTION
Nothing much. Just a typo.
