### PR TITLE
Fixed class cast exception of addon enable with custom repices

### DIFF
--- a/src/minecraft/org/getspout/spout/inventory/SimpleMaterialManager.java
+++ b/src/minecraft/org/getspout/spout/inventory/SimpleMaterialManager.java
@@ -248,17 +248,15 @@ public class SimpleMaterialManager implements MaterialManager {
 	}
 	public boolean registerRecipe(Recipe recipe) {
 		SpoutcraftRecipe toAdd;
-		if (recipe instanceof Recipe) {
-			toAdd = (SpoutcraftRecipe) recipe;
+		
+		if (recipe instanceof ShapedRecipe) {
+			toAdd = SimpleShapedRecipe.fromSpoutRecipe((ShapedRecipe) recipe);
+		} else if (recipe instanceof ShapelessRecipe) {
+			toAdd = SimpleShapelessRecipe.fromSpoutRecipe((ShapelessRecipe) recipe);
 		} else {
-			if (recipe instanceof ShapedRecipe) {
-				toAdd = SimpleShapedRecipe.fromSpoutRecipe((ShapedRecipe) recipe);
-			} else if (recipe instanceof ShapelessRecipe) {
-				toAdd = SimpleShapelessRecipe.fromSpoutRecipe((ShapelessRecipe) recipe);
-			} else {
-				return false;
-			}
+			return false;
 		}
+		
 		toAdd.addToCraftingManager();
 		return true;
 	}


### PR DESCRIPTION
The downcast from Recipe to SpoutcraftRecipe was causing a class cast exception, and seemed unnecessary.  This removes it, and for me at least, allows custom recipes to work.
