### PR TITLE
Proper ItemWidget scaling

### DIFF
--- a/src/minecraft/org/spoutcraft/client/gui/MCRenderDelegate.java
+++ b/src/minecraft/org/spoutcraft/client/gui/MCRenderDelegate.java
@@ -261,7 +261,9 @@ public class MCRenderDelegate implements RenderDelegate {
 		}
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float) item.getScreenX(), (float) item.getScreenY(), 0);
-		GL11.glScalef((float) (item.getScreen().getWidth() / 427f), (float) (item.getScreen().getHeight() / 240f), 1);
+		if (item.getAnchor() == WidgetAnchor.SCALE) {
+			GL11.glScalef((float) (item.getScreen().getWidth() / 427f), (float) (item.getScreen().getHeight() / 240f), 1);
+		}
 		int id = item.getTypeId();
 		int data = item.getData();
 		if (MaterialData.getCustomItem(id) != null) {


### PR DESCRIPTION
Before the ItemWidgets were sized relatively to the screen even if it should not do this. With this commit it only happens when the Anchor is set to SCALE, which is the desired effect.
