### PR TITLE
Enabled custom names on Potions

### DIFF
--- a/src/minecraft/net/minecraft/src/GuiContainer.java
+++ b/src/minecraft/net/minecraft/src/GuiContainer.java
@@ -115,7 +115,7 @@ public abstract class GuiContainer extends GuiScreen
 			List<String> list = itemstack.getItemNameandInformation();
 			org.spoutcraft.spoutcraftapi.material.Material item = MaterialData.getMaterial(slot.getStack().itemID, (short)(slot.getStack().getItemDamage()));
 			String custom = item != null ? String.format(item.getName(), String.valueOf(slot.getStack().getItemDamage())) : null;
-			if (custom != null && slot.getStack().itemID != MaterialData.potion.getRawId()) {
+			if (custom != null) {
 				list.set(0, custom);
 			}
 			if(list.size() > 0)


### PR DESCRIPTION
Allows plugins to change the name of potions.

This patch is designed to work with the changes in these pull requests [SpoutPluginAPI#17](https://github.com/SpoutDev/SpoutPluginAPI/pull/17) [SpoutcraftAPI#19](https://github.com/SpoutDev/SpoutcraftAPI/pull/19) as without those changes the client and server will not register the presence of the various potion subtypes.
