### PR TITLE
Patch to make Spout's entityData persist across respawn.

### DIFF
--- a/src/minecraft/net/minecraft/client/Minecraft.java
+++ b/src/minecraft/net/minecraft/client/Minecraft.java
@@ -1828,6 +1828,8 @@ public abstract class Minecraft implements Runnable {
 		this.thePlayer = (EntityPlayerSP) this.playerController.createPlayer(this.theWorld);
 		if (par3) {
 			this.thePlayer.copyPlayer(var9);
+		} else {
+			this.thePlayer.setData(oldPlayer.getData()); //even in MP still need to copy Spout data across
 		}
 
 		this.thePlayer.dimension = par2;

--- a/src/minecraft/net/minecraft/src/EntityLiving.java
+++ b/src/minecraft/net/minecraft/src/EntityLiving.java
@@ -1564,8 +1564,12 @@ public abstract class EntityLiving extends Entity {
 	}
 //Spout Start
 	
-	public final EntityData getData() {
+	public EntityData getData() {
 		return entityData;
+	}
+	
+	public void setData(EntityData e) {
+		this.entityData = e;
 	}
 	
 	public String getCustomTextureUrl(byte id){


### PR DESCRIPTION
Simply copies over the previous entity's data while we're creating the new player entity during respawn. This allows things like gravity, run-speed and swim-speed multipliers to persist across re-spawn.

Is possible that this copying should also be done in EntityPlayer.java:copyPlayer() but as far as I can see this is only used in Single Player so I've left it alone.
