### PR TITLE
Fixed Unsupported Operation

### DIFF
--- a/src/minecraft/net/minecraft/src/Packet18Animation.java
+++ b/src/minecraft/net/minecraft/src/Packet18Animation.java
@@ -9,6 +9,7 @@ import net.minecraft.src.Packet;
 
 //Spout Start
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class Packet18Animation extends Packet {
 			((NetClientHandler) par1NetHandler).addToSendQueue(this);
 			SpoutClient.getInstance().getPacketManager().sendSpoutPacket(new PacketRenderDistance((byte)Minecraft.theMinecraft.gameSettings.renderDistance));
 			SpoutClient.getInstance().getPacketManager().sendSpoutPacket(new PacketFullVersion(Long.toString(SpoutClient.getClientVersion())));
-			List<Addon> addons = Arrays.asList(SpoutClient.getInstance().getAddonManager().getAddons());
+			List<Addon> addons = new ArrayList<Addon>(Arrays.asList(SpoutClient.getInstance().getAddonManager().getAddons()));
 			for (Iterator<Addon> i = addons.iterator(); i.hasNext(); ) if(!Spoutcraft.getAddonStore().isEnabled(i.next())) i.remove();
 			SpoutClient.getInstance().getPacketManager().sendSpoutPacket(new PacketClientAddons(addons.toArray(new Addon[0])));
 			System.out.println("Detected Spout server.");


### PR DESCRIPTION
The List returned by Arrays.asList() doesn't let you remove items from it, so a new ArrayList is formed to encompass it - thus solving the issue.
