### PR TITLE
Text alpha

### DIFF
--- a/src/minecraft/net/minecraft/src/FontRenderer.java
+++ b/src/minecraft/net/minecraft/src/FontRenderer.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Random;
 import javax.imageio.ImageIO;
 import org.lwjgl.opengl.GL11;
+import org.spoutcraft.client.config.ConfigReader;		//spout alphaText
 
 public class FontRenderer {
 	private int[] charWidth = new int[256];
@@ -329,7 +330,13 @@ public class FontRenderer {
 					var7 = false;
 					var6 = false;
 					var5 = false;
-					GL11.glColor4f(this.field_50115_n, this.field_50116_o, this.field_50118_p, this.field_50117_q);
+					//spout start alphaText
+					if (ConfigReader.alphaText) {
+						GL11.glColor4f(this.field_50115_n, this.field_50116_o, this.field_50118_p, this.field_50117_q);
+					} else {
+						GL11.glColor3f(this.field_50115_n, this.field_50116_o, this.field_50118_p);
+					}
+					//spout end
 				}
 
 				++var8;
@@ -397,7 +404,13 @@ public class FontRenderer {
 			this.field_50116_o = (float)(par4 >> 8 & 255) / 255.0F;
 			this.field_50118_p = (float)(par4 & 255) / 255.0F;
 			this.field_50117_q = (float)(par4 >> 24 & 255) / 255.0F;
-			GL11.glColor4f(this.field_50115_n, this.field_50116_o, this.field_50118_p, this.field_50117_q);
+			//spout start alphaText
+			if (ConfigReader.alphaText) {
+				GL11.glColor4f(this.field_50115_n, this.field_50116_o, this.field_50118_p, this.field_50117_q);
+			} else {
+				GL11.glColor3f(this.field_50115_n, this.field_50116_o, this.field_50118_p);
+			}
+			//spout end
 			this.posX = (float)par2;
 			this.posY = (float)par3;
 			this.renderStringAtPos(par1Str, par5);

--- a/src/minecraft/org/spoutcraft/client/config/ConfigReader.java
+++ b/src/minecraft/org/spoutcraft/client/config/ConfigReader.java
@@ -84,7 +84,8 @@ public class ConfigReader {
 	public static boolean clientLight = false;
 	public static float flightSpeedMultiplier = 2.0F;
 	public static boolean askBeforeOpeningUrl = true;
-	
+	public static boolean alphaText = true;
+
 	//Launcher settings
 	public static boolean fastLogin = false;
 	public static boolean clipboardaccess = false;

--- a/src/minecraft/org/spoutcraft/client/gui/settings/GameSettingsScreen.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/GameSettingsScreen.java
@@ -417,6 +417,12 @@ public class GameSettingsScreen extends GuiScreen{
 		control = new FlightSpeedSlider().setAlign(WidgetAnchor.TOP_CENTER);
 		control.setWidth(150).setHeight(20).setX(right).setY(top);
 		screen.attachWidget(spoutcraft, control);
+
+		top += 22;
+
+		control = new TextAlphaToggleButton().setAlign(WidgetAnchor.TOP_CENTER);
+		control.setWidth(150).setHeight(20).setX(left).setY(top);
+		screen.attachWidget(spoutcraft, control);
 	}
 
 	@Override

--- a/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
@@ -35,7 +35,7 @@ public class TextAlphaToggleButton extends GenericCheckBox{
 		super("Text Alpha");
 		setChecked(ConfigReader.alphaText);
 		setEnabled(true);
-		setTooltip("Text Alpha\nON - Text is colored in §4R§2G§1B§eA§f (Default)\nOFF  - Text is rendered in §4R§2G§1B§f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.");
+		setTooltip("Text Alpha\nON - Text is colored in \u00A74R\u00A72G\u00A71B\u00A7eA\u00A7f (Default)\nOFF  - Text is rendered in \u00A74R\u00A72G\u00A71B\u00A7f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.");
 	}
 
 	@Override

--- a/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
@@ -35,7 +35,7 @@ public class TextAlphaToggleButton extends GenericCheckBox{
 		super("Text Alpha");
 		setChecked(ConfigReader.alphaText);
 		setEnabled(true);
-		setTooltip("Text Alpha\nON - Text is colored in §4R§2G§1B§eA§f (Default)\nOFF  - Text is rendered in §4R§2G§1B§f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.\n§00§11§22§33§44§55§66§77§88§99§aa§bb§cc§dd§ee§ff§ll§mm§nn§oo§rr§kk");
+		setTooltip("Text Alpha\nON - Text is colored in ï¿½4Rï¿½2Gï¿½1Bï¿½eAï¿½f (Default)\nOFF  - Text is rendered in ï¿½4Rï¿½2Gï¿½1Bï¿½f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.");
 	}
 
 	@Override

--- a/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Spoutcraft (http://www.spout.org/).
+ *
+ * Spoutcraft is licensed under the SpoutDev License Version 1.
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev license version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spoutcraft.client.gui.settings;
+
+import org.spoutcraft.client.SpoutClient;
+import org.spoutcraft.client.config.ConfigReader;
+import org.spoutcraft.spoutcraftapi.event.screen.ButtonClickEvent;
+import org.spoutcraft.spoutcraftapi.gui.GenericCheckBox;
+
+public class TextAlphaToggleButton extends GenericCheckBox{
+	public TextAlphaToggleButton() {
+		super("Text Alpha");
+		setChecked(ConfigReader.alphaText);
+		setEnabled(true);
+		setTooltip("Text Alpha\nON - Text is colored in §4R§2G§1B§eA§f (Default)\nOFF  - Text is rendered in §4R§2G§1B§f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.\n§00§11§22§33§44§55§66§77§88§99§aa§bb§cc§dd§ee§ff§ll§mm§nn§oo§rr§kk");
+	}
+
+	@Override
+	public String getTooltip() {
+		if (!isEnabled()) {
+			return "This option is not allowed, meow.";
+		}
+		return super.getTooltip();
+	}
+
+	@Override
+	public void onButtonClick(ButtonClickEvent event) {
+		ConfigReader.alphaText = !ConfigReader.alphaText;
+		ConfigReader.write();
+	}
+}

--- a/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/TextAlphaToggleButton.java
@@ -35,7 +35,7 @@ public class TextAlphaToggleButton extends GenericCheckBox{
 		super("Text Alpha");
 		setChecked(ConfigReader.alphaText);
 		setEnabled(true);
-		setTooltip("Text Alpha\nON - Text is colored in �4R�2G�1B�eA�f (Default)\nOFF  - Text is rendered in �4R�2G�1B�f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.");
+		setTooltip("Text Alpha\nON - Text is colored in §4R§2G§1B§eA§f (Default)\nOFF  - Text is rendered in §4R§2G§1B§f.\nSwitching off trades transparent text for coloured text,\nrestoring colour to most machines with the white text bug.");
 	}
 
 	@Override


### PR DESCRIPTION
Allows players to switch to RGB colour space for rendering text. This allows players afflected by the white text bug to trade transparent text for colour.
