### PR TITLE
Camera detaching

### DIFF
--- a/src/minecraft/org/spoutcraft/client/entity/CraftCameraEntity.java
+++ b/src/minecraft/org/spoutcraft/client/entity/CraftCameraEntity.java
@@ -1,7 +1,10 @@
 package org.spoutcraft.client.entity;
 
 import org.spoutcraft.spoutcraftapi.entity.CameraEntity;
+import org.spoutcraft.spoutcraftapi.property.Property;
 import org.spoutcraft.spoutcraftapi.util.FixedLocation;
+import org.spoutcraft.spoutcraftapi.util.Location;
+import org.spoutcraft.spoutcraftapi.util.Vector;
 
 public class CraftCameraEntity extends CraftEntity implements CameraEntity {
 	
@@ -9,6 +12,22 @@ public class CraftCameraEntity extends CraftEntity implements CameraEntity {
 		super(location);
 		handle = new EntityCamera(this);
 		teleport(location);
+		addProperty("location", new Property() {
+			public void set(Object value) {
+				teleport((Location)value);
+			}
+			public Object get() {
+				return getLocation();
+			}
+		});
+		addProperty("velocity", new Property() {
+			public void set(Object value) {
+				setVelocity((Vector)value);
+			}
+			public Object get() {
+				return getVelocity();
+			}
+		});
 	}
 	
 	@Override

--- a/src/minecraft/org/spoutcraft/client/entity/CraftCameraEntity.java
+++ b/src/minecraft/org/spoutcraft/client/entity/CraftCameraEntity.java
@@ -1,0 +1,25 @@
+package org.spoutcraft.client.entity;
+
+import org.spoutcraft.spoutcraftapi.entity.CameraEntity;
+import org.spoutcraft.spoutcraftapi.util.FixedLocation;
+
+public class CraftCameraEntity extends CraftEntity implements CameraEntity {
+	
+	public CraftCameraEntity(FixedLocation location) {
+		super(location);
+		handle = new EntityCamera(this);
+		teleport(location);
+	}
+	
+	@Override
+	public boolean teleport(FixedLocation location) {
+		handle.setPositionAndRotation(location.getX(), location.getY(), location.getZ(), (float)location.getYaw(), (float)location.getPitch());
+		((EntityCamera)handle).setRotation((float)location.getYaw(), (float)location.getPitch());
+		return true;
+	}
+	
+	public EntityCamera getHandle() {
+		return (EntityCamera) handle;
+	}
+
+}

--- a/src/minecraft/org/spoutcraft/client/entity/EntityCamera.java
+++ b/src/minecraft/org/spoutcraft/client/entity/EntityCamera.java
@@ -1,0 +1,43 @@
+package org.spoutcraft.client.entity;
+
+import org.spoutcraft.client.SpoutClient;
+
+import net.minecraft.src.DamageSource;
+import net.minecraft.src.EntityPlayerSP;
+
+public class EntityCamera extends EntityPlayerSP {
+
+	public EntityCamera(CraftCameraEntity spoutEntity) {
+		super(SpoutClient.getHandle(), SpoutClient.getHandle().theWorld, SpoutClient.getHandle().session, SpoutClient.getHandle().thePlayer.dimension);
+		yOffset = 1.62F;
+		this.spoutEntity = spoutEntity;
+	}
+	
+	@Override
+	public boolean canBePushed() {
+		return false;
+	}
+	
+	@Override
+	public void onEntityUpdate() { }
+	
+	@Override
+	public void onDeath(DamageSource source) { }
+	
+	@Override
+	public boolean isEntityAlive() {
+		return true;
+	}
+	
+	public void setRotation(float yaw, float pitch) {
+		lastTickPosX = posX;
+		lastTickPosY = posY;
+		lastTickPosZ = posZ;
+		
+		prevRotationYaw = rotationYaw;
+		prevRotationPitch = rotationPitch;
+		rotationYaw = yaw;
+		rotationPitch = pitch;
+	}
+
+}


### PR DESCRIPTION
Well, title says everything :P
- Changes to SpoutcraftAPI:
  - There is a CameraEntity interface in the API and Client.getCamera() returns the CameraEntity (null if not detached).
- Changes to Spoutcraft:
  - CraftCameraEntity implements CameraEntity
  - EntityCamera which extends Minecraft's EntityPlayerSP (the renderViewEntity in Minecraft main class needs to be a player, otherwise it will break some core things)

Corresponding SpoutcraftAPI pull request: https://github.com/SpoutDev/SpoutcraftAPI/pull/23

Sorry, but the files in the first commit got 'refreshed' or how you say it. :(
