### PR TITLE
Finished Slot implementation server-side.

### DIFF
--- a/src/minecraft/net/minecraft/src/GuiScreen.java
+++ b/src/minecraft/net/minecraft/src/GuiScreen.java
@@ -284,6 +284,8 @@ public class GuiScreen extends Gui
 			if(mc.thePlayer == null) {
 				return;
 			}
+			PacketSlotClick packet = new PacketSlotClick(slot, button,Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT));
+			SpoutClient.getInstance().getPacketManager().sendSpoutPacket(packet);
 			ItemStack stackOnCursor = new ItemStack(0);
 			if(mc.thePlayer.inventory.getItemStack() != null) {
 				net.minecraft.src.ItemStack mcStack = mc.thePlayer.inventory.getItemStack();
@@ -344,7 +346,7 @@ public class GuiScreen extends Gui
 					slot.setItem(put);
 				}
 			} else if (stackOnCursor == null || stackOnCursor.getTypeId() == 0) { //Take item or shift click
-				if(Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
+				if(Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
 					slot.onItemShiftClicked();
 				} else { //Take item
 					boolean success = slot.onItemTake(stackInSlot);

--- a/src/minecraft/org/spoutcraft/client/gui/MCRenderDelegate.java
+++ b/src/minecraft/org/spoutcraft/client/gui/MCRenderDelegate.java
@@ -30,17 +30,14 @@ import org.lwjgl.opengl.GL11;
 import org.newdawn.slick.opengl.Texture;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.src.Block;
 import net.minecraft.src.Entity;
 import net.minecraft.src.FontRenderer;
 import net.minecraft.src.FoodStats;
 import net.minecraft.src.GuiButton;
 import net.minecraft.src.GuiIngame;
-import net.minecraft.src.GuiScreen;
 import net.minecraft.src.Item;
 import net.minecraft.src.Material;
 import net.minecraft.src.Potion;
-import net.minecraft.src.RenderBlocks;
 import net.minecraft.src.RenderHelper;
 import net.minecraft.src.RenderManager;
 import net.minecraft.src.ScaledResolution;
@@ -237,26 +234,12 @@ public class MCRenderDelegate implements RenderDelegate {
 		GL11.glEnable(GL11.GL_TEXTURE_2D);
 		GL11.glEnable(GL11.GL_COLOR_MATERIAL);
 		GL11.glDisable(GL11.GL_LIGHTING);
-		double oldX = 1;
-		double oldY = 1;
-		double oldZ = 1;
-		Block block = null;
-		if (item.getTypeId() < 255 && RenderBlocks.renderItemIn3d(Block.blocksList[item.getTypeId()].getRenderType())) {
-			block = Block.blocksList[item.getTypeId()];
-			oldX = block.maxX;
-			oldY = block.maxY;
-			oldZ = block.maxZ;
-			block.maxX = block.maxX * item.getWidth() / 8;
-			block.maxY = block.maxY * item.getHeight() / 8;
-			block.maxZ = block.maxZ * item.getDepth() / 8;
-		} else {
-			renderer.setScale((item.getWidth() / 8D), (item.getHeight() / 8D), 1);
-		}
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float) item.getScreenX(), (float) item.getScreenY(), 0);
 		if (item.getAnchor() == WidgetAnchor.SCALE) {
 			GL11.glScalef((float) (item.getScreen().getWidth() / 427f), (float) (item.getScreen().getHeight() / 240f), 1);
 		}
+		GL11.glScaled(item.getWidth() / 16D, item.getHeight() / 16D, 1);
 		int id = item.getTypeId();
 		int data = item.getData();
 		if (MaterialData.getCustomItem(id) != null) {
@@ -266,11 +249,7 @@ public class MCRenderDelegate implements RenderDelegate {
 		}
 		renderer.drawItemIntoGui(SpoutClient.getHandle().fontRenderer, SpoutClient.getHandle().renderEngine, id, data, Item.itemsList[id].getIconFromDamage(item.getData()), 0, 0);
 		GL11.glPopMatrix();
-		if (item.getTypeId() < 255 && RenderBlocks.renderItemIn3d(Block.blocksList[item.getTypeId()].getRenderType())) {
-			block.maxX = oldX;
-			block.maxY = oldY;
-			block.maxZ = oldZ;
-		}
+		GL11.glScaled(16D / item.getWidth(), 16D / item.getHeight(), 1);
 		GL11.glEnable(GL11.GL_DEPTH_TEST);
 		GL11.glEnable(GL11.GL_LIGHTING);
 		RenderHelper.disableStandardItemLighting();
@@ -908,26 +887,12 @@ public class MCRenderDelegate implements RenderDelegate {
 			GL11.glEnable(GL11.GL_TEXTURE_2D);
 			GL11.glEnable(GL11.GL_COLOR_MATERIAL);
 			GL11.glDisable(GL11.GL_LIGHTING);
-			double oldX = 1;
-			double oldY = 1;
-			double oldZ = 1;
-			Block block = null;
-			if (item.getTypeId() < 255 && RenderBlocks.renderItemIn3d(Block.blocksList[item.getTypeId()].getRenderType())) {
-				block = Block.blocksList[item.getTypeId()];
-				oldX = block.maxX;
-				oldY = block.maxY;
-				oldZ = block.maxZ;
-				block.maxX = block.maxX * genericSlot.getWidth() / 16;
-				block.maxY = block.maxY * genericSlot.getHeight() / 16;
-				block.maxZ = block.maxZ * genericSlot.getDepth() / 16;
-			} else {
-				renderer.setScale((genericSlot.getWidth() / 8D), (genericSlot.getHeight() / 8D), 1);
-			}
 			GL11.glPushMatrix();
 			GL11.glTranslatef((float) genericSlot.getScreenX(), (float) genericSlot.getScreenY(), 0);
 			if (genericSlot.getAnchor() == WidgetAnchor.SCALE) {
 				GL11.glScalef((float) (genericSlot.getScreen().getWidth() / 427f), (float) (genericSlot.getScreen().getHeight() / 240f), 1);
 			}
+			GL11.glScaled(genericSlot.getWidth() / 16D, genericSlot.getHeight() / 16D, 1);
 			int id = item.getTypeId();
 			int data = item.getDurability();
 			if (MaterialData.getCustomItem(id) != null) {
@@ -938,11 +903,7 @@ public class MCRenderDelegate implements RenderDelegate {
 			renderer.drawItemIntoGui(SpoutClient.getHandle().fontRenderer, SpoutClient.getHandle().renderEngine, id, data, Item.itemsList[id].getIconFromDamage(item.getDurability()), 0, 0);
 			renderer.renderItemOverlayIntoGUI(SpoutClient.getHandle().fontRenderer, SpoutClient.getHandle().renderEngine, new net.minecraft.src.ItemStack(id, item.getAmount(), data), 0, 0);
 			GL11.glPopMatrix();
-			if (item.getTypeId() < 255 && RenderBlocks.renderItemIn3d(Block.blocksList[item.getTypeId()].getRenderType())) {
-				block.maxX = oldX;
-				block.maxY = oldY;
-				block.maxZ = oldZ;
-			}
+			GL11.glScaled(16D / genericSlot.getWidth(), 16D / genericSlot.getHeight(), 1);
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
 			GL11.glEnable(GL11.GL_LIGHTING);
 			RenderHelper.disableStandardItemLighting();
@@ -952,6 +913,10 @@ public class MCRenderDelegate implements RenderDelegate {
 			int y = (int) genericSlot.getScreenY();
 			int width = (int) (x + genericSlot.getWidth());
 			int height = (int) (y + genericSlot.getHeight());
+			x = (int) ((x * genericSlot.getWidth()) / 16);
+			y = (int) ((y * genericSlot.getHeight()) / 16);
+			width = (int) ((width * genericSlot.getWidth()) / 16);
+			height = (int) ((height * genericSlot.getHeight()) / 16);
 			RenderUtil.drawRectangle(x, y, width, height, 0x88ffffff);
 		}
 	}

--- a/src/minecraft/org/spoutcraft/client/packet/PacketSlotClick.java
+++ b/src/minecraft/org/spoutcraft/client/packet/PacketSlotClick.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Spoutcraft (http://www.spout.org/).
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.spoutcraft.client.packet;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.spoutcraft.spoutcraftapi.gui.Slot;
+
+public class PacketSlotClick implements SpoutPacket {
+	private UUID screen;
+	private UUID slot;
+	private int mouseClick;
+	private boolean holdingShift;
+
+	public PacketSlotClick() {
+	}
+
+	public PacketSlotClick(Slot slot, int mouseClick, boolean holdingShift) {
+		screen = slot.getScreen().getId();
+		this.slot = slot.getId();
+		this.mouseClick = mouseClick;
+		this.holdingShift = holdingShift;
+	}
+
+	public void readData(DataInputStream input) throws IOException {
+		long msb = input.readLong();
+		long lsb = input.readLong();
+		screen = new UUID(msb,lsb);msb = input.readLong();
+		msb = input.readLong();
+		lsb = input.readLong();
+		slot = new UUID(msb,lsb);
+		mouseClick = input.readByte();
+		holdingShift = input.readBoolean();
+	}
+
+	public void writeData(DataOutputStream output) throws IOException {
+		output.writeLong(screen.getMostSignificantBits());
+		output.writeLong(screen.getLeastSignificantBits());//16
+		output.writeLong(slot.getMostSignificantBits());
+		output.writeLong(slot.getLeastSignificantBits());//32
+		output.writeByte(mouseClick);//mouseClick will usually be 0 (left) or 1 (right) - so this is safe unless the mouse has... 257 buttons :P
+		output.writeBoolean(holdingShift);//34
+	}
+
+	public int getNumBytes() {
+		return 34;
+	}
+
+	public void run(int playerId) {
+	}
+
+	public void failure(int playerId) {
+	}
+
+	public PacketType getPacketType() {
+		return PacketType.PacketSlotClick;
+	}
+
+	public int getVersion() {
+		return 0;
+	}
+}

--- a/src/minecraft/org/spoutcraft/client/packet/PacketType.java
+++ b/src/minecraft/org/spoutcraft/client/packet/PacketType.java
@@ -75,8 +75,9 @@ public enum PacketType {
 	PacketEntityInformation(53, PacketEntityInformation.class),
 	PacketComboBox(54, PacketComboBox.class),
 	PacketFocusUpdate(55, PacketFocusUpdate.class),
-	PacketClientAddons(56, PacketClientAddons.class), 
+	PacketClientAddons(56, PacketClientAddons.class),
 	PacketPermissionUpdate(57, PacketPermissionUpdate.class),
+	PacketSlotClick(58, PacketSlotClick.class),
 	;
 
 	private final int id;


### PR DESCRIPTION
This is the Spoutcraftimplementation of SpoutPluginAPI PR #22 (https://github.com/SpoutDev/SpoutPluginAPI/pull/22)

In addition,  I modified the code in MCRender for GenericItemWidget and GenericSlot to use a glScale call instead of some funky other stuff. By changing it to a glScale, 1) GenericItemWidget and GenericSlot now render to the proper dimensions and 2) they scale properly.
