### PR TITLE
The text shadow of a Label can now be disabled. 

### DIFF
--- a/src/minecraft/org/spoutcraft/client/gui/MCRenderDelegate.java
+++ b/src/minecraft/org/spoutcraft/client/gui/MCRenderDelegate.java
@@ -299,7 +299,8 @@ public class MCRenderDelegate implements RenderDelegate {
 			float scale = label.getScale();
 			float reset = 1 / scale;
 			GL11.glScalef(scale, scale, scale);
-			font.drawStringWithShadow(lines[i], (int) left, i * 10, label.getTextColor().toInt());
+			if(label.hasShadow()) font.drawStringWithShadow(lines[i], (int) left, i * 10, label.getTextColor().toInt());
+			else font.drawString(lines[i], (int) left, i * 10, label.getTextColor().toInt());
 			GL11.glScalef(reset, reset, reset);
 		}
 		GL11.glPopMatrix();


### PR DESCRIPTION
This corresponds with SpoutPluginAPI PR 24 (https://github.com/SpoutDev/SpoutPluginAPI/pull/24)
