### PR TITLE
Screenshots can now be resized.

### DIFF
--- a/src/minecraft/net/minecraft/client/Minecraft.java
+++ b/src/minecraft/net/minecraft/client/Minecraft.java
@@ -1189,7 +1189,7 @@ public abstract class Minecraft implements Runnable {
 		}
 	}
 
-	private void resize(int par1, int par2) {
+	public void resize(int par1, int par2) {
 		if (par1 <= 0) {
 			par1 = 1;
 		}

--- a/src/minecraft/net/minecraft/src/ScreenShotHelper.java
+++ b/src/minecraft/net/minecraft/src/ScreenShotHelper.java
@@ -7,8 +7,14 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import javax.imageio.ImageIO;
+
+import net.minecraft.client.Minecraft;
+
 import org.lwjgl.BufferUtils;
+import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.EXTFramebufferObject;
 import org.lwjgl.opengl.GL11;
+import org.spoutcraft.client.config.ConfigReader;
 
 public class ScreenShotHelper {
 
@@ -20,7 +26,8 @@ public class ScreenShotHelper {
 	//Spout End
 
 	public static String saveScreenshot(File par0File, int par1, int par2) {
-		return saveScreenshot(par0File, (String)null, par1, par2);
+		if(ConfigReader.resizeScreenshots) return saveResizedScreenshot(par0File, ConfigReader.resizedScreenshotWidth, ConfigReader.resizedScreenshotHeight);
+		else return saveScreenshot(par0File, (String)null, par1, par2);
 	}
 
 	//Spout Start - method renamed from func_35879_a to saveScreenshot
@@ -105,4 +112,88 @@ public class ScreenShotHelper {
 		return bufferedimage;
 	}
 	//Spout end
+	
+	public static String saveResizedScreenshot(File base, int width, int height) {
+		int texture = GL11.glGenTextures();
+		GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture);
+		GL11.glTexEnvf( GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE );
+		GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0 , 3, width, height, 0 , GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, (ByteBuffer) null);
+		
+		int buffer = EXTFramebufferObject.glGenFramebuffersEXT();
+		EXTFramebufferObject.glBindFramebufferEXT(EXTFramebufferObject.GL_FRAMEBUFFER_EXT, buffer);
+		EXTFramebufferObject.glFramebufferTexture2DEXT(EXTFramebufferObject.GL_FRAMEBUFFER_EXT, EXTFramebufferObject.GL_COLOR_ATTACHMENT0_EXT, GL11.GL_TEXTURE_2D, texture, 0);
+		
+		int renderbuffer = EXTFramebufferObject.glGenRenderbuffersEXT();
+		EXTFramebufferObject.glBindRenderbufferEXT(EXTFramebufferObject.GL_RENDERBUFFER_EXT, renderbuffer);
+		EXTFramebufferObject.glRenderbufferStorageEXT( EXTFramebufferObject.GL_RENDERBUFFER_EXT, GL11.GL_DEPTH_COMPONENT, width, height);
+		EXTFramebufferObject.glFramebufferRenderbufferEXT( EXTFramebufferObject.GL_FRAMEBUFFER_EXT, EXTFramebufferObject.GL_DEPTH_ATTACHMENT_EXT, EXTFramebufferObject.GL_RENDERBUFFER_EXT, renderbuffer);
+		
+		int oldwidth = Minecraft.theMinecraft.displayWidth;
+		int oldheight = Minecraft.theMinecraft.displayHeight;
+		//resize
+		Minecraft.theMinecraft.resize(width, height);
+		//draw world
+		Minecraft.theMinecraft.entityRenderer.renderWorld(0, 0);
+		//draw gui
+		ScaledResolution res = new ScaledResolution(Minecraft.theMinecraft.gameSettings, width, height);
+		int renderwidth = Mouse.getX() * res.getScaledWidth() / width;
+		int renderheight = res.getScaledHeight() - Mouse.getY() * res.getScaledHeight() / height - 1;
+		if (!Minecraft.theMinecraft.gameSettings.hideGUI || Minecraft.theMinecraft.currentScreen != null) {
+			Minecraft.theMinecraft.ingameGUI.renderGameOverlay(0, Minecraft.theMinecraft.currentScreen != null, renderwidth, renderheight);
+		}
+		if (Minecraft.theMinecraft.currentScreen != null) {
+			GL11.glClear(256);
+			// Spout Start
+			Minecraft.theMinecraft.currentScreen.drawScreenPre(renderwidth, renderheight, 0);
+			// Spout End
+			if (Minecraft.theMinecraft.currentScreen != null && Minecraft.theMinecraft.currentScreen.guiParticles != null) {
+				Minecraft.theMinecraft.currentScreen.guiParticles.draw(0);
+			}
+		}
+		//return to old size
+		Minecraft.theMinecraft.resize(oldwidth, oldheight);
+		
+		EXTFramebufferObject.glBindFramebufferEXT(EXTFramebufferObject.GL_FRAMEBUFFER_EXT, 0);
+		EXTFramebufferObject.glBindRenderbufferEXT(EXTFramebufferObject.GL_RENDERBUFFER_EXT, 0);
+		
+		BufferedImage image = ScreenShotHelper.getScreenshot(texture, width, height);
+		File screenshotsDir = new File(base, "screenshots");
+		screenshotsDir.mkdir();
+		File file;
+		String s1 = (new StringBuilder()).append("").append(dateFormat.format(new Date())).toString();
+		for (int k = 1; (file = new File(screenshotsDir, (new StringBuilder()).append(s1).append(k != 1 ? (new StringBuilder()).append("_").append(k).toString() : "").append(".png").toString())).exists(); k++) ;
+		try {
+			ImageIO.write(image, "png", file);
+			return (new StringBuilder()).append("Saved screenshot as ").append(file.getName()).toString();
+		} catch(Exception e) {
+			e.printStackTrace();
+			return (new StringBuilder()).append("Failed to save: ").append(e).toString();
+		}
+		//return saveScreenshot(par0File, (String)null, par1, par2);
+	}
+
+	
+	public static BufferedImage getScreenshot(int texture, int screenWidth, int screenHeight) {
+		ByteBuffer buffer = BufferUtils.createByteBuffer(screenWidth * screenHeight * 3);
+		byte[] pixelData = new byte[screenWidth * screenHeight * 3];
+		int[] imageData = new int[screenWidth * screenHeight];
+		buffer.clear();
+		GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture);
+		GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, buffer);
+		buffer.clear();
+		buffer.get(pixelData);
+		for (int l = 0; l < screenWidth; l++) {
+			for (int i1 = 0; i1 < screenHeight; i1++) {
+				int j1 = l + (screenHeight - i1 - 1) * screenWidth;
+				int k1 = pixelData[j1 * 3 + 0] & 0xff;
+				int l1 = pixelData[j1 * 3 + 1] & 0xff;
+				int i2 = pixelData[j1 * 3 + 2] & 0xff;
+				int j2 = 0xff000000 | k1 << 16 | l1 << 8 | i2;
+				imageData[l + i1 * screenWidth] = j2;
+			}
+		}
+		BufferedImage bufferedimage = new BufferedImage(screenWidth, screenHeight, 1);
+		bufferedimage.setRGB(0, 0, screenWidth, screenHeight, imageData, 0, screenWidth);
+		return bufferedimage;
+	}
 }

--- a/src/minecraft/org/spoutcraft/client/config/ConfigReader.java
+++ b/src/minecraft/org/spoutcraft/client/config/ConfigReader.java
@@ -80,6 +80,9 @@ public class ConfigReader {
 	public static boolean replaceTools = false;
 	public static boolean replaceBlocks = false;
 	public static boolean hotbarQuickKeysEnabled = true;
+	public static boolean resizeScreenshots = false;
+	public static int resizedScreenshotWidth = 6000;
+	public static int resizedScreenshotHeight = 3200;
 	
 	//Launcher settings
 	public static boolean fastLogin = false;

--- a/src/minecraft/org/spoutcraft/client/gui/settings/GameSettingsScreen.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/GameSettingsScreen.java
@@ -431,6 +431,47 @@ public class GameSettingsScreen extends GuiScreen{
 		control = new HotbarQuickKeysButton().setAlign(WidgetAnchor.TOP_CENTER);
 		control.setWidth(150).setHeight(20).setX(left).setY(top);
 		screen.attachWidget(spoutcraft, control);
+
+		top += 22;
+		
+		top += 5;
+		
+		label = new GenericLabel("Screenshot Settings");
+		size = Spoutcraft.getMinecraftFont().getTextWidth(label.getText());
+		label.setX((int) (width / 2 - size / 2)).setY(top);
+		label.setTextColor(grey);
+		screen.attachWidget(spoutcraft, label);
+		top += 11;
+
+		linebreak = new GenericGradient();
+		linebreak.setBottomColor(grey);
+		linebreak.setTopColor(grey);
+		linebreak.setX(width/2 - 318 / 2).setY(top).setHeight(3).setWidth(318);
+		screen.attachWidget(spoutcraft, linebreak);
+		top += 6;
+
+		control = new ResizeScreenshotButton().setAlign(WidgetAnchor.TOP_CENTER);
+		control.setWidth(150).setHeight(20).setX(left).setY(top);
+		screen.attachWidget(spoutcraft, control);
+		top += 22;
+
+		label = new GenericLabel("Screenshot Width:");
+		label.setWidth(150).setHeight(20).setX(left).setY(top);
+		screen.attachWidget(spoutcraft, label);
+
+		control = new ResizeScreenshotWidthField();
+		control.setWidth(150).setHeight(15).setX(right).setY(top + 2);
+		screen.attachWidget(spoutcraft, control);
+		top += 22;
+
+		label = new GenericLabel("Screenshot Height:");
+		label.setWidth(150).setHeight(20).setX(left).setY(top);
+		screen.attachWidget(spoutcraft, label);
+
+		control = new ResizeScreenshotHeightField();
+		control.setWidth(150).setHeight(15).setX(right).setY(top + 2);
+		screen.attachWidget(spoutcraft, control);
+		top += 22;
 	}
 
 	@Override

--- a/src/minecraft/org/spoutcraft/client/gui/settings/ResizeScreenshotButton.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/ResizeScreenshotButton.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Spoutcraft (http://www.spout.org/).
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.spoutcraft.client.gui.settings;
+
+import org.spoutcraft.client.config.ConfigReader;
+import org.spoutcraft.spoutcraftapi.event.screen.ButtonClickEvent;
+import org.spoutcraft.spoutcraftapi.gui.GenericCheckBox;
+
+public class ResizeScreenshotButton extends GenericCheckBox{
+	public ResizeScreenshotButton() {
+		super("Resize Screenshots");
+		setChecked(ConfigReader.resizeScreenshots);
+		setTooltip("Screenshots will be rendered at an alternate dimension.\nOFF - (Default) Screenshots are the size of your window.\nON - Screenshots are the specified dimension.");
+	}
+
+	@Override
+	public void onButtonClick(ButtonClickEvent event) {
+		ConfigReader.resizeScreenshots = !ConfigReader.resizeScreenshots;
+		ConfigReader.write();
+	}
+}

--- a/src/minecraft/org/spoutcraft/client/gui/settings/ResizeScreenshotHeightField.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/ResizeScreenshotHeightField.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Spoutcraft (http://www.spout.org/).
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.spoutcraft.client.gui.settings;
+
+import org.spoutcraft.client.config.ConfigReader;
+import org.spoutcraft.spoutcraftapi.gui.Control;
+import org.spoutcraft.spoutcraftapi.gui.GenericTextField;
+
+public class ResizeScreenshotHeightField extends GenericTextField {
+	public ResizeScreenshotHeightField() {
+		setTooltip("The height to resize the screenshot to.");
+		setText("");
+		setPlaceholder("" + ConfigReader.resizedScreenshotHeight);
+		setMaximumCharacters(4);
+	}
+
+	@Override
+	public void onTick() {
+		setEnabled(ConfigReader.resizeScreenshots);
+		super.onTick();
+	}
+	
+	@Override
+	public void onTypingFinished() {
+		if(getText().equals("")) return;
+		try {
+			int height = Integer.parseInt(getText());
+			if(height < 1) throw new RuntimeException("Must be at least 1");
+			ConfigReader.resizedScreenshotHeight = height;
+			ConfigReader.write();
+			setPlaceholder("" + height);
+		} catch(Exception e) {
+			setText("");
+			setPlaceholder("Error");
+			setFocus(false);
+		}
+	}
+	
+	@Override
+	public Control setFocus(boolean focus) {
+		super.setFocus(focus);
+		if(!focus) {
+			try {
+				int height = Integer.parseInt(getText());
+				if(height < 1) throw new RuntimeException("Must be at least 1");
+				ConfigReader.resizedScreenshotHeight = height;
+				ConfigReader.write();
+				setText("");
+				setPlaceholder("" + height);
+			} catch(Exception e) {
+				setText("");
+				setPlaceholder("Error");
+			}
+		}
+		return this;
+	}
+}

--- a/src/minecraft/org/spoutcraft/client/gui/settings/ResizeScreenshotWidthField.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/ResizeScreenshotWidthField.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Spoutcraft (http://www.spout.org/).
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.spoutcraft.client.gui.settings;
+
+import org.spoutcraft.client.config.ConfigReader;
+import org.spoutcraft.spoutcraftapi.gui.Control;
+import org.spoutcraft.spoutcraftapi.gui.GenericTextField;
+
+public class ResizeScreenshotWidthField extends GenericTextField {
+	public ResizeScreenshotWidthField() {
+		setTooltip("The width to resize the screenshot to.");
+		setText("");
+		setPlaceholder("" + ConfigReader.resizedScreenshotWidth);
+		setMaximumCharacters(4);
+	}
+
+	@Override
+	public void onTick() {
+		setEnabled(ConfigReader.resizeScreenshots);
+		super.onTick();
+	}
+	
+	@Override
+	public void onTypingFinished() {
+		if(getText().equals("")) return;
+		try {
+			int width = Integer.parseInt(getText());
+			if(width < 1) throw new RuntimeException("Must be at least 1");
+			ConfigReader.resizedScreenshotWidth = width;
+			ConfigReader.write();
+			setPlaceholder("" + width);
+		} catch(Exception e) {
+			setText("");
+			setPlaceholder("Error");
+			setFocus(false);
+		}
+	}
+	
+	@Override
+	public Control setFocus(boolean focus) {
+		super.setFocus(focus);
+		if(!focus) {
+			try {
+				int width = Integer.parseInt(getText());
+				if(width < 1) throw new RuntimeException("Must be at least 1");
+				ConfigReader.resizedScreenshotWidth = width;
+				ConfigReader.write();
+				setText("");
+				setPlaceholder("" + width);
+			} catch(Exception e) {
+				setText("");
+				setPlaceholder("Error");
+			}
+		}
+		return this;
+	}
+}


### PR DESCRIPTION
Made some changes to ScreenShotHelper that let you re-render the screen at any size for a screenshot. Currently I have the size input (under options) limited to 9999x9999 because things don't seem to work well with higher sizes. In addition, a new section to configure it has been added to the options menu. Erm.... that seems to cover it :D
