### PR TITLE
Custom character width detection fix.

### DIFF
--- a/src/minecraft/net/minecraft/src/GuiScreen.java
+++ b/src/minecraft/net/minecraft/src/GuiScreen.java
@@ -946,7 +946,7 @@ public class GuiScreen extends Gui
 	// Note: already inside of the sandbox
 	public void drawTooltip(String tooltip, int x, int y) {
 		GL11.glPushMatrix();
-		String lines[] = tooltip.split("\n");
+		String lines[] = this.fontRenderer.func_50113_d(tooltip,(width-22)).split("\n");	// Meow- Autowrap tooltips to reported screen width
 		int tooltipWidth = 0;
 		int tooltipHeight = 8 * lines.length + 3;
 		for (String line : lines) {


### PR DESCRIPTION
Uses Alpha instead of Green channel to determine opacity in a custom font texture, allowing characer widths to be determined correctly.

Also trims most of the 'garbage' off of fullwidth characters, though with large font textures (1024^2) a single column of garbage pixels will remain.

Changed 'colIdx' back from 'pixel' to maintain consistency with pclewis/mcpatcher.

Signed-off-by: dluechoy dluechoy@gmail.com
