### PR TITLE
PacketParticle now spawns particles at large ranges

### DIFF
--- a/src/minecraft/net/minecraft/src/RenderGlobal.java
+++ b/src/minecraft/net/minecraft/src/RenderGlobal.java
@@ -1516,6 +1516,10 @@ public class RenderGlobal implements IWorldAccess {
 	}
 
 	public EntityFX func_40193_b(String par1Str, double par2, double par4, double par6, double par8, double par10, double par12) {
+		return func_40193_b(par1Str, par2, par4, par6, par8, par10, par12, 16.0);
+	}
+
+	public EntityFX func_40193_b(String par1Str, double par2, double par4, double par6, double par8, double par10, double par12, double var22) { //Spout
 		if (this.mc != null && this.mc.renderViewEntity != null && this.mc.effectRenderer != null) {
 			int var14 = this.mc.gameSettings.particleSetting;
 			if (var14 == 1 && this.worldObj.rand.nextInt(3) == 0) {
@@ -1535,7 +1539,6 @@ public class RenderGlobal implements IWorldAccess {
 			if (var21 != null) {
 				return (EntityFX)var21;
 			} else {
-				double var22 = 16.0D;
 				//Spout start
 				if (!org.spoutcraft.client.config.ConfigReader.fancyParticles) {
 					var22 = 6D;

--- a/src/minecraft/org/spoutcraft/client/packet/PacketParticle.java
+++ b/src/minecraft/org/spoutcraft/client/packet/PacketParticle.java
@@ -48,7 +48,7 @@ public class PacketParticle implements SpoutPacket {
 				y += (r.nextBoolean() ? 2 : -2) * r.nextFloat();
 				z += (r.nextBoolean() ? 2 : -2) * r.nextFloat();
 			}
-			EntityFX particle = Minecraft.theMinecraft.renderGlobal.func_40193_b(name, x, y, z, motion.getX(), motion.getY(), motion.getZ());
+			EntityFX particle = Minecraft.theMinecraft.renderGlobal.func_40193_b(name, x, y, z, motion.getX(), motion.getY(), motion.getZ(), 256D);
 			if (particle != null) {
 				if (scale > 0) {
 					particle.particleScale = scale;


### PR DESCRIPTION
Range checking now performed in SpoutPlugin - reduces sending of unnecessary particle packets to every player, and allows a server admin to customize the range if required.

With fancy particles off, the range is still limited.

SpoutPlugin PR: https://github.com/SpoutDev/SpoutPlugin/pull/44

Signed-off-by: Ross Allan rallanpcl@gmail.com
