### PR TITLE
Fix SPOUTCRAFT-322: disabled DifficultyButton is now enabled again in single player mode

### DIFF
--- a/src/minecraft/org/spoutcraft/client/gui/settings/DifficultyButton.java
+++ b/src/minecraft/org/spoutcraft/client/gui/settings/DifficultyButton.java
@@ -51,7 +51,7 @@ public class DifficultyButton extends GenericButton {
 		if (Minecraft.theMinecraft.theWorld == null) {
 			return "Can not change difficulty outside of the game";
 		}
-		if (Minecraft.theMinecraft.isMultiplayerWorld()) {
+		if (!Minecraft.theMinecraft.isSingleplayer()) {
 			return "Can not change difficulty in multiplayer";
 		}
 		if (Minecraft.theMinecraft.theWorld.getWorldInfo().isHardcoreModeEnabled()) {
@@ -65,7 +65,7 @@ public class DifficultyButton extends GenericButton {
 		if (Minecraft.theMinecraft.theWorld == null) {
 			return false;
 		}
-		if (Minecraft.theMinecraft.isMultiplayerWorld()) {
+		if (!Minecraft.theMinecraft.isSingleplayer()) {
 			return false;
 		}
 		if (Minecraft.theMinecraft.theWorld.getWorldInfo().isHardcoreModeEnabled()) {


### PR DESCRIPTION
As isMultiplayerWorld always returns true now, i used isSingleplayer instead, because it checks if the integrated server is up and running.
