### PR TITLE
fixed senseless thread spawning in MapCalculator class

### DIFF
--- a/src/minecraft/org/spoutcraft/client/gui/minimap/MapCalculator.java
+++ b/src/minecraft/org/spoutcraft/client/gui/minimap/MapCalculator.java
@@ -415,20 +415,11 @@ public class MapCalculator implements Runnable {
 	 * Called each tick of the render.
 	 */
 	void onRenderTick() {
-		if (zCalc == null || !zCalc.isAlive()) {
-			zCalc = new Thread(this);
-			zCalc.start();
-		}
 		if (Minecraft.theMinecraft != null
 				&& Minecraft.theMinecraft.theWorld != null) {
 			tryARender();
 		}
 	}
-
-	/**
-	 * Map calculation thread
-	 */
-	public Thread zCalc = new Thread(this);
 
 	/**
 	 * Random used to distort cave map
@@ -453,7 +444,6 @@ public class MapCalculator implements Runnable {
 	 * the thread will be restarted by the keep-alive in onRenderTick().
 	 */
 	public void start() {
-		zCalc.start();
 	}
 
 	public static int getHeightColor(short height, short reference) {


### PR DESCRIPTION
When i debugged Spoutcraft i came over a bunch of threads initialized a second and wondered why. Found the solution in MapCalculator as there is a Thread reinitialized every game tick, that does totally nothing in its run method. Removed the crap until it does something useful. For now, it only uses system resources and get eclipse to hang when you try to debug Spoutcraft.
