### PR TITLE
HTTP proxy support for multiplayer connections

### DIFF
--- a/src/minecraft/net/minecraft/src/NetClientHandler.java
+++ b/src/minecraft/net/minecraft/src/NetClientHandler.java
@@ -23,6 +23,7 @@ import org.lwjgl.input.Keyboard;
 import org.spoutcraft.client.SpoutClient;
 import org.spoutcraft.client.config.ConfigReader;
 import org.spoutcraft.client.io.FileDownloadThread;
+import org.spoutcraft.client.io.ProxyManager;
 import org.spoutcraft.spoutcraftapi.entity.LivingEntity;
 
 public class NetClientHandler extends NetHandler {
@@ -63,7 +64,15 @@ public class NetClientHandler extends NetHandler {
 	
 	public NetClientHandler(Minecraft par1Minecraft, String par2Str, int par3) throws IOException {
 		this.mc = par1Minecraft;
-		Socket var4 = new Socket(InetAddress.getByName(par2Str), par3);
+    //spout start
+    Socket var4;
+    if(ProxyManager.isEnabled()){
+      var4 = ProxyManager.proxyConnect(par2Str, par3);
+    }
+    else{
+		  var4 = new Socket(InetAddress.getByName(par2Str), par3);
+    }
+    //spout end :)
 		this.netManager = new TcpConnection(var4, "Client", this);
 
 		org.spoutcraft.client.gui.error.GuiConnectionLost.lastServerIp = par2Str; // Spout

--- a/src/minecraft/org/spoutcraft/client/gui/server/PollResult.java
+++ b/src/minecraft/org/spoutcraft/client/gui/server/PollResult.java
@@ -36,6 +36,7 @@ import gnu.trove.map.hash.TIntObjectHashMap;
 
 import org.spoutcraft.client.SpoutClient;
 import org.spoutcraft.client.io.MirrorUtils;
+import org.spoutcraft.client.io.ProxyManager;
 import org.spoutcraft.client.util.NetworkUtils;
 
 public class PollResult {
@@ -180,17 +181,23 @@ public class PollResult {
 			DataOutputStream output = null;
 			try {
 				long start = System.currentTimeMillis();
-				sock = new Socket();
-				sock.setSoTimeout(10000);
-				InetSocketAddress address = NetworkUtils.resolve(ip, port);
-				if (address.isUnresolved()) {
-					ping = PING_UNKNOWN;
-					return;
-				}
-				sock.connect(address, 10000);
-				sock.setTcpNoDelay(true);
-				sock.setTrafficClass(18);
+        
+        if(ProxyManager.isEnabled()){
+          sock = ProxyManager.proxyConnect(ip, port);
+        }
+        else{
+          sock = new Socket();
+          sock.setSoTimeout(10000);
+          InetSocketAddress address = NetworkUtils.resolve(ip, port);
+          if (address.isUnresolved()) {
+            ping = PING_UNKNOWN;
+            return;
+          }
 
+          sock.connect(address, 10000);
+          sock.setTcpNoDelay(true);
+          sock.setTrafficClass(18);
+        }
 				input = new DataInputStream(sock.getInputStream());
 				output = new DataOutputStream(sock.getOutputStream());
 

--- a/src/minecraft/org/spoutcraft/client/io/Base64.java
+++ b/src/minecraft/org/spoutcraft/client/io/Base64.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Spoutcraft.
+ *
+ * Copyright (c) 2011-2012, SpoutDev <http://www.spout.org/>
+ * Spoutcraft is licensed under the GNU Lesser General Public License.
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.spoutcraft.client.io;
+
+public class Base64 {
+  private static final String base64code = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz" + "0123456789" + "+/";
+  private static final int splitLinesAt = 76;
+
+  public static String encode(String string) {
+    String encoded = "";
+    byte[] stringArray;
+    try {
+      stringArray = string.getBytes("UTF-8");  // use appropriate encoding string!
+    } catch (Exception ignored) {
+      stringArray = string.getBytes();  // use locale default rather than croak
+    }
+    // determine how many padding bytes to add to the output
+    int paddingCount = (3 - (stringArray.length % 3)) % 3;
+    // add any necessary padding to the input
+    stringArray = zeroPad(stringArray.length + paddingCount, stringArray);
+    // process 3 bytes at a time, churning out 4 output bytes
+    // worry about CRLF insertions later
+    for (int i = 0; i < stringArray.length; i += 3) {
+      int j = ((stringArray[i] & 0xff) << 16)
+              + ((stringArray[i + 1] & 0xff) << 8)
+              + (stringArray[i + 2] & 0xff);
+      encoded = encoded + base64code.charAt((j >> 18) & 0x3f)
+              + base64code.charAt((j >> 12) & 0x3f)
+              + base64code.charAt((j >> 6) & 0x3f)
+              + base64code.charAt(j & 0x3f);
+    }
+    // replace encoded padding nulls with "="
+    return splitLines(encoded.substring(0, encoded.length()
+            - paddingCount) + "==".substring(0, paddingCount));
+  }
+
+  private static String splitLines(String string) {
+    String lines = "";
+    for (int i = 0; i < string.length(); i += splitLinesAt) {
+      lines += string.substring(i, Math.min(string.length(), i + splitLinesAt));
+      lines += "\r\n";
+    }
+    return lines;
+  }
+
+  private static byte[] zeroPad(int length, byte[] bytes) {
+    byte[] padded = new byte[length]; // initialized to zero by JVM
+    System.arraycopy(bytes, 0, padded, 0, bytes.length);
+    return padded;
+  }
+}

--- a/src/minecraft/org/spoutcraft/client/io/ProxyManager.java
+++ b/src/minecraft/org/spoutcraft/client/io/ProxyManager.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Spoutcraft.
+ *
+ * Copyright (c) 2011-2012, SpoutDev <http://www.spout.org/>
+ * Spoutcraft is licensed under the GNU Lesser General Public License.
+ *
+ * Spoutcraft is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Spoutcraft is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.spoutcraft.client.io;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.Socket;
+import java.util.Properties;
+
+
+public class ProxyManager {
+  private static Properties prop = new Properties();
+  private static File proxyConfigFile = new File(FileUtil.getConfigDir(), "proxySettings.properties");
+  
+  public static boolean isEnabled(){
+    try {
+      prop.load(new FileInputStream(proxyConfigFile));
+    }
+    catch(Exception e){
+      return false;
+    }
+    
+    return prop.getProperty("enabled").equalsIgnoreCase("true");
+  }
+  
+  public static Socket proxyConnect(String host, int port) throws IOException{
+    Socket skt = new Socket(prop.getProperty("host"), Integer.parseInt(prop.getProperty("port")));
+    PrintStream out = new PrintStream(skt.getOutputStream());
+    BufferedReader in = new BufferedReader(new InputStreamReader(skt.getInputStream()));
+    out.println("CONNECT " + host + ":" + port + " HTTP/1.1");
+    
+    if(!prop.getProperty("user").isEmpty() && ! prop.getProperty("pass").isEmpty()){
+      //basic http proxy authentication
+      out.println("Proxy-Authorization: basic " + Base64.encode(prop.getProperty("user") + ":" + prop.getProperty("pass")));
+    }
+    //try block untill connection is ready. proxy should return http 200 code
+    System.out.println("Proxy connect to: " + host + ":" + port + in.readLine());
+    return skt;
+  }
+  
+}
+
+


### PR DESCRIPTION
I created this issue SPOUTCRAFTLAUNCHER-12 ages ago. Afforess added proxy parameters for the launcher which was awesome but they don't work for spoutcraft socket connections like polling or connecting to mc servers. This is the only solution I could think of: use a proxy settings configuration file.

I meant to make this one commit but forgot to add two files.
